### PR TITLE
Invoke hugo directly, rather than via sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 echo "#################################################"
 echo "Starting the Hugo Action"
 
-sh -c "hugo $*"
+hugo "$@"
 
 echo "#################################################"
 echo "Completed the Hugo Action"


### PR DESCRIPTION
This allows passing each argument separately (`"$@"`) instead of concatenated into a single string (`"$*"`). The latter will break on whitespace, quotes, and other special characters.